### PR TITLE
feat: add symptoms_started_on

### DIFF
--- a/immuni_analytics/models/exposure_data.py
+++ b/immuni_analytics/models/exposure_data.py
@@ -69,6 +69,7 @@ class ExposurePayload(Document):
     """
 
     province = StringField(required=True)
+    symptoms_started_on = DateField(required=False)
     exposure_detection_summaries = EmbeddedDocumentListField(
         ExposureDetectionSummary, required=False, default=[]
     )
@@ -89,9 +90,12 @@ class ExposurePayload(Document):
         ):
             raise ValidationError()
 
+        symptoms_started_on = payload.get("symptoms_started_on", None)
+
         return ExposurePayload(
             **{
                 "province": province,
+                "symptoms_started_on": symptoms_started_on,
                 "exposure_detection_summaries": [
                     asdict(ExposureDetectionSummarySchema().load(e))
                     for e in exposure_detection_summaries

--- a/immuni_analytics/models/exposure_data.py
+++ b/immuni_analytics/models/exposure_data.py
@@ -69,6 +69,9 @@ class ExposurePayload(Document):
     """
 
     province = StringField(required=True)
+    # NOTE: the field is marked as not required to support any data forwarded by the
+    # first version of the Exposure Ingestion Service, which did not include symptoms_started_on.
+    # It will be changed as soon as all the old data have been collected.
     symptoms_started_on = DateField(required=False)
     exposure_detection_summaries = EmbeddedDocumentListField(
         ExposureDetectionSummary, required=False, default=[]

--- a/tests/fixtures/exposure_data.py
+++ b/tests/fixtures/exposure_data.py
@@ -25,6 +25,7 @@ def exposure_data_dict() -> Dict[str, Any]:
         version=1,
         payload=dict(
             province="AG",
+            symptoms_started_on="2020-01-12",
             exposure_detection_summaries=[
                 {
                     "date": "2020-01-11",


### PR DESCRIPTION
## Description

Add the `symptoms_started_on` field (not required for validation).

## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket: