### PR TITLE
fix: add expiration for authorized analytics tokens

### DIFF
--- a/immuni_analytics/celery/authorization_ios/tasks/authorize_analytics_token.py
+++ b/immuni_analytics/celery/authorization_ios/tasks/authorize_analytics_token.py
@@ -200,6 +200,9 @@ async def _add_analytics_token_to_redis(analytics_token: str) -> None:
 
     :param analytics_token: the analytics token to authorize for upload.
     """
-    await managers.analytics_redis.sadd(analytics_token, *get_all_authorizations_for_upload())
+    pipe = managers.analytics_redis.pipeline()
+    pipe.sadd(analytics_token, *get_all_authorizations_for_upload())
+    pipe.expire(analytics_token, config.ANALYTICS_TOKEN_EXPIRATION_DAYS * 60)
+    await pipe.execute()
     _LOGGER.info("New authorized analytics token.", extra=dict(analytics_token=analytics_token))
     AUTHORIZE_ANALYTICS_TOKEN_AUTHORIZED.inc()

--- a/immuni_analytics/core/config.py
+++ b/immuni_analytics/core/config.py
@@ -24,6 +24,9 @@ ANALYTICS_BROKER_REDIS_URL: str = config(
 ANALYTICS_MONGO_URL = config(
     "ANALYTICS_MONGO_URL", default="mongodb://localhost:27017/immuni-analytics-dev"
 )
+ANALYTICS_TOKEN_EXPIRATION_DAYS: int = config(
+    "ANALYTICS_TOKEN_EXPIRATION_MINUTES", cast=int, default=62
+)
 ANALYTICS_TOKEN_SIZE: int = config("ANALYTICS_TOKEN_SIZE", cast=int, default=128)
 APPLE_CERTIFICATE_KEY: str = config(
     "APPLE_CERTIFICATE_KEY", cast=load_certificate("APPLE_CERTIFICATE_KEY"), default=""


### PR DESCRIPTION
## Description

This PR adds the expiration to the keys related to the authorized analytics tokens. The default validity is 62 days.


## Checklist

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
