### PR TITLE
fix(mongoengine): use abstract meta to allow consistent collection name

### DIFF
--- a/immuni_analytics/models/analytics_document.py
+++ b/immuni_analytics/models/analytics_document.py
@@ -26,7 +26,7 @@ class AnalyticsDocument(Document):
     Document base class providing a method to comply with the data retention policy.
     """
 
-    meta: Dict[str, Any] = dict(allow_inheritance=True)
+    meta: Dict[str, Any] = dict(abstract=True)
 
     @classmethod
     def delete_older_than(cls, reference_date: datetime) -> int:


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

All MongoDB collections inheriting from AnalyticsDocument were ending up in a collection named `_analytics_document`.

This PR aims at having each collection with its name.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
