### PR TITLE
feat(monitoring): add province to operational_info_requests

### DIFF
--- a/immuni_analytics/monitoring/api.py
+++ b/immuni_analytics/monitoring/api.py
@@ -24,7 +24,7 @@ OPERATIONAL_INFO_REQUESTS = Counter(
     namespace=NAMESPACE,
     subsystem=Subsystem.API.value,
     name="operational_info_requests",
-    labelnames=("dummy", "platform", "http_status"),
+    labelnames=("dummy", "platform", "province", "http_status"),
     documentation="Number of operational info requests the server responded to.",
 )
 

--- a/immuni_analytics/monitoring/helpers.py
+++ b/immuni_analytics/monitoring/helpers.py
@@ -43,11 +43,16 @@ def monitor_operational_info(f: Callable[..., Coroutine[Any, Any, HTTPResponse]]
     async def _wrapper(*args: Any, is_dummy: bool, **kwargs: Any) -> HTTPResponse:
         request = args[0]
         platform = _ENDPOINT_PLATFORM_TO_PLATFORM[request.uri_template.split("/")[3]]
+        province = kwargs["province"]
         try:
             response = await f(*args, **kwargs)
-            OPERATIONAL_INFO_REQUESTS.labels(is_dummy, platform, response.status).inc()
+            OPERATIONAL_INFO_REQUESTS.labels(
+                is_dummy, platform.value, province, response.status
+            ).inc()
         except ApiException as error:
-            OPERATIONAL_INFO_REQUESTS.labels(is_dummy, platform, error.status_code.value).inc()
+            OPERATIONAL_INFO_REQUESTS.labels(
+                is_dummy, platform.value, province, error.status_code.value
+            ).inc()
             raise
         return response
 


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

A little tweak on the metrics for operational info requests so as to better monitor them.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:
