### PR TITLE
fix(decorators): platform driven inject_operational_info

### DIFF
--- a/immuni_analytics/apis/analytics.py
+++ b/immuni_analytics/apis/analytics.py
@@ -51,7 +51,7 @@ from immuni_common.core.exceptions import SchemaValidationException
 from immuni_common.helpers.sanic import handle_dummy_requests, json_response, validate
 from immuni_common.helpers.swagger import doc_exception
 from immuni_common.helpers.utils import WeightedPayload
-from immuni_common.models.enums import Location
+from immuni_common.models.enums import Location, Platform
 from immuni_common.models.marshmallow.fields import (
     Base64String,
     IntegerBoolField,
@@ -103,7 +103,7 @@ bp = Blueprint("analytics", url_prefix="analytics")
 @handle_dummy_requests(
     [WeightedPayload(weight=1, payload=json_response(body=None, status=HTTPStatus.NO_CONTENT))]
 )
-@inject_operational_info
+@inject_operational_info(platform=Platform.IOS)
 async def post_apple_operational_info(
     request: Request, operational_info: OperationalInfoDocument, **kwargs: Any
 ) -> HTTPResponse:
@@ -164,7 +164,7 @@ async def post_apple_operational_info(
 @handle_dummy_requests(
     [WeightedPayload(weight=1, payload=json_response(body=None, status=HTTPStatus.NO_CONTENT))]
 )
-@inject_operational_info
+@inject_operational_info(platform=Platform.ANDROID)
 async def post_android_operational_info(
     request: Request,
     last_risky_exposure_on: date,


### PR DESCRIPTION
<!--- IMPORTANT: Please review [how to contribute](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md) before proceeding further. -->
<!--- IMPORTANT: If this is a Work in Progress PR, please mark it as such in GitHub. -->

## Description

<!--- Describe in detail the proposed mods -->

The previous implementation would always hardcode the platform to IOS for each OperationalInfo document, regardless of the operational-info endpoint being called (i.e., apple, google).

This PR avoids such behavior by requiring the previously faulty decorator to gather the platform while calling it.

## Checklist

<!--- Please insert an ‘x’ after you complete each step -->

- [x] I have followed the indications in the [CONTRIBUTING](https://github.com/immuni-app/immuni-backend-analytics/blob/master/CONTRIBUTING.md).
- [x] The documentation related to the proposed change has been updated accordingly (plus comments in code).
- [x] I have written new tests for my core changes, as applicable.
- [x] I have successfully run tests with my changes locally.
- [x] It is ready for review! :rocket:

